### PR TITLE
Important change to filterResults.R

### DIFF
--- a/R/SSModelBase.R
+++ b/R/SSModelBase.R
@@ -52,7 +52,7 @@ SSModelBase <- setRefClass(
     },
     get_model = function(y, q = NULL)
     {
-      return(stop('NotImplementedError: Implement in subclass with your model'))
+      return(stop('Not Implemented Error: Implement in subclass with your model'))
     },
     get_dynamic_gompertz_model = function(
       y,
@@ -203,7 +203,7 @@ SSModelBase <- setRefClass(
       "Update method for Kalman filter to implement the dynamic Gompertz curve
        model.
        A maximum of 3 parameters are used to set the observation noise
-       (1 param), the transition equation slope and seaonal noise. If q (signal
+       (1 parameter), the transition equation slope and seasonal noise. If q (signal
         to noise ratio) is not null then the slope noise is set using this
         ratio.
        \\subsection{Parameters}{\\itemize{

--- a/R/SSModelDynGompertzReinit.R
+++ b/R/SSModelDynGompertzReinit.R
@@ -191,7 +191,7 @@ SSModelDynGompertzReinit <- setRefClass(
             ncol(model_output$att) - 1}
         }
 
-        # 4.3 Reset slope to 0 and add constant to intial value for level.
+        # 4.3 Reset slope to 0 and add constant to initial value for level.
         # where reinit.date is t=r
         idx <- which(reinit.date == index(y))
         stopifnot(length(idx) == 1)

--- a/R/data.R
+++ b/R/data.R
@@ -27,7 +27,7 @@
 #'
 #' @keywords datasets
 #'
-#' @references tba
+#' @references Downloaded from https://sacoronavirus.co.za/
 #'
 #' @examples
 #' data(gauteng)
@@ -50,7 +50,7 @@
 #'
 #' @keywords datasets
 #'
-#' @references Downloaded from https://api.coronavirus.data.gov.uk/v2/data
+#' @references Downloaded from https://ukhsa-dashboard.data.gov.uk/topics/covid-19
 #'
 #' @examples
 #' data(england)

--- a/R/data.R
+++ b/R/data.R
@@ -14,7 +14,7 @@
 #  A copy of the GNU General Public License is available at
 #  http://www.r-project.org/Licenses/
 
-#' Cumlative cases of Covid-19 in the South African provence of Gauteng.
+#' Cumulative cases of Covid-19 in the South African province of Gauteng.
 #'
 #' @docType data
 #'
@@ -37,7 +37,7 @@
 
 
 
-#' Cumlative cases of Covid-19 in England.
+#' Cumulative cases of Covid-19 in England.
 #'
 #' @docType data
 #'

--- a/R/filterResults.R
+++ b/R/filterResults.R
@@ -57,7 +57,7 @@ FilterResults <- setRefClass(
       return.diff = FALSE)
     {
       "Forecast the cumulated variable or the incidence of it. This function returns
-      the forecast of the cumulated variable \\eqn{Y}, or the forecast of the incidence of the cumulated variable, \eqn{y}. For
+      the forecast of the cumulated variable \\eqn{Y}, or the forecast of the incidence of the cumulated variable, \\eqn{y}. For
       example, in the case of an epidemic, \\eqn{y} might be daily new cases of
       the disease and
        \\eqn{Y} the cumulative number of recorded infections.

--- a/R/filterResults.R
+++ b/R/filterResults.R
@@ -24,7 +24,7 @@ setOldClass("KFS")
 #' res <- model$estimate()
 #' # Print estimation results
 #' res$print_estimation_results()
-#' # Forecast 7 days ahead from the model
+#' # Forecast 7 days ahead from the end of the estimation window
 #' res$predict_level(y.cum = gauteng[idx.est], n.ahead = 7,
 #'   confidence_level = 0.68)
 #' # Forecast 7 days ahead from the model and return filtered states
@@ -63,8 +63,8 @@ FilterResults <- setRefClass(
        \\eqn{Y} the cumulative number of recorded infections.
        \\subsection{Parameters}{\\itemize{
         \\item{\\code{y.cum} The cumulated variable.}
-        \\item{\\code{n.ahead} The number of forecasts you wish to create from
-        the end of your sample period.}
+        \\item{\\code{n.ahead} The number of periods ahead you wish to forecast from
+        the end of the estimation window.}
         \\item{\\code{confidence_level} The confidence level for the log growth
          rate that should be used to compute
         the forecast intervals of \\eqn{y}.}
@@ -153,7 +153,7 @@ FilterResults <- setRefClass(
 
       out <- tbl %>%
         kableExtra::kbl(
-          caption = "Estimated params",
+          caption = "Estimated parameters",
           col.names = header.names,
           format = 'latex',
           booktabs = TRUE,
@@ -183,7 +183,7 @@ FilterResults <- setRefClass(
       (and filtered, where applicable) level
       of \\eqn{y} (\\code{y.hat}), \\eqn{\\delta} (\\code{level.t.t}),
       \\eqn{\\gamma} (\\code{slope.t.t}), vector of states including the
-      seasonals where applicable (\\code{a.t.t}) and covaraince matrix of all
+      seasonals where applicable (\\code{a.t.t}) and covariance matrix of all
       states including seasonals where applicable (\\code{P.t.t}).}"
       idx <- index
       model <- output

--- a/R/filterResults.R
+++ b/R/filterResults.R
@@ -56,8 +56,8 @@ FilterResults <- setRefClass(
       sea.on = FALSE,
       return.diff = FALSE)
     {
-      "Forecast the incidence of the cumulated variable. This function returns
-      the forecast incidence, \\eqn{y}, of the cumulated variable \\eqn{Y}. For
+      "Forecast the cumulated variable or the incidence of it. This function returns
+      the forecast of the cumulated variable \\eqn{Y}, or the forecast of the incidence of the cumulated variable, \eqn{y}. For
       example, in the case of an epidemic, \\eqn{y} might be daily new cases of
       the disease and
        \\eqn{Y} the cumulative number of recorded infections.
@@ -68,9 +68,9 @@ FilterResults <- setRefClass(
         \\item{\\code{confidence_level} The confidence level for the log growth
          rate that should be used to compute
         the forecast intervals of \\eqn{y}.}
-        \\item{\\code{return.diff} Logical value indicating whether to return
-        \\eqn{y} or the first difference of
-        \\eqn{y} (e.g. the change in daily new cases). Default is
+        \\item{\\code{return.diff} Logical value indicating whether to return the cumulated variable,
+        \\eqn{Y}, or the incidence of it,
+        \\eqn{y} (i.e., the first difference of the cumulated variable). Default is
         \\code{FALSE}.}
       }}
       \\subsection{Return Value}{\\code{xts} object containing the point

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,10 +18,10 @@
 #
 #' @description Helper method to compute the log growth rates of cumulated
 #' variables. It will compute the log cumulative growth rate for each column in
-#' the dataframe.
+#' the data frame.
 #'
 #' @param dt Cumulated data series.
-#' @returns A dataframe of log growth rates of the cumulated variable which has
+#' @returns A data frame of log growth rates of the cumulated variable which has
 #' been inputted via the parameter \code{dt}.
 #'
 #' @examples
@@ -37,13 +37,13 @@ df2ldl <- function(dt) {
 }
 
 
-#' @title Reinitialise a dataframe by subtracting the `reinit.date` row from
+#' @title Reinitialise a data frame by subtracting the `reinit.date` row from
 #' all columns
 #'
 #' @param dt Cumulated data series.
 #' @param reinit.date Reinitialisation date. E.g. \samp{'2021-05-12'}.
 #'
-#' @returns The reinitialised dataframe
+#' @returns The reinitialised data frame
 #'
 #' @examples
 #' library(tsgc)
@@ -71,7 +71,7 @@ reinitialise_dataframe <- function(dt, reinit.date) {
 #' @param decreasing Logical value indicating whether \code{x} should be
 #' ordered in decreasing order. Default is \code{TRUE}. Setting this to
 #' \code{FALSE} would find the minimum.
-#' @returns The maxmium value and its index.
+#' @returns The maximum value and its index.
 #' @examples
 #' library(tsgc)
 #' data(gauteng,package="tsgc")
@@ -93,7 +93,7 @@ argmax <- function(x, decreasing=TRUE) {
 #' @param res Results object estimated using the \samp{estimate()} method.
 #' @param  res.dir File path to save the results to.
 #' @param Y Cumulated variable.
-#' @param n.ahead Number of forecasts to make.
+#' @param n.ahead Number of periods ahead to forecast.
 #' @param confidence.level Confidence level to use for the confidence interval
 #' on the forecasts \eqn{\ln(g_t)}.
 #' 
@@ -187,7 +187,7 @@ write_results <- function(res, res.dir, Y, n.ahead, confidence.level) {
 }
 
 
-## TODO: Can move to FilterResults.
+
 #' @title Returns forecast of number of periods until peak given
 #' \code{KFAS::KFS} output.
 #'
@@ -197,7 +197,7 @@ write_results <- function(res, res.dir, Y, n.ahead, confidence.level) {
 #' \eqn{\ell} is given by
 #' \deqn{\ell = \frac{\ln(-\gamma_{T|T})-\delta_{T|T}}{\gamma_{T|T}}.} This is
 #' predicated on \eqn{\gamma_{T|T}<0}, else there is super-exponential growth
-#' an no peak in sight. Of course, it only makes sense to investigate an
+#' and no peak in sight. Of course, it only makes sense to investigate an
 #' upcoming peak for \eqn{g_{y,T|T}>0} (when cases are growing). The estimates
 #' of \eqn{\delta_{T|T}} and \eqn{\gamma_{T|T}} are extracted from the
 #' \code{KFS} object passed to the function.


### PR DESCRIPTION
An inadvertent typo in line 60 of filterResults.R ("\eqn{y}" instead of "\\eqn{y}") prevented the package from being installable. This is now corrected.